### PR TITLE
feat: enrich span tags and add client interceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,59 @@
 # dd-trace-go-contrib-connect
 
+Datadog APM tracing interceptors for [connect-go](https://connectrpc.com/).
+
+## Usage
+
+```go
+import (
+	"connectrpc.com/connect"
+	connecttrace "github.com/cskd8/dd-trace-go-contrib-connect"
+)
+
+// Server side
+path, handler := examplev1connect.NewExampleServiceHandler(svc, connect.WithInterceptors(
+	connecttrace.NewServerInterceptor(connecttrace.WithService("my-service")),
+))
+
+// Client side
+client := examplev1connect.NewExampleServiceClient(httpClient, baseURL, connect.WithInterceptors(
+	connecttrace.NewClientInterceptor(connecttrace.WithService("my-service")),
+))
+```
+
+The client interceptor traces unary calls and injects the trace context into the
+request headers. For streaming client calls it only propagates the trace context.
+
+## Span tags
+
+Tags set on every span:
+
+| Tag | Example |
+|-----|---------|
+| `connect.method.name` | `/example.v1.ExampleService/Get` |
+| `connect.method.kind` | `unary` |
+| `connect.code` | `ok`, `internal`, ... |
+| `connect.protocol` | `connect`, `grpc`, `grpcweb` |
+| `connect.peer.addr` | client address (server spans) / server host (client spans) |
+| `component` | `connectrpc.com/connect` |
+| `rpc.system` | `connect` |
+| `rpc.service` | `example.v1.ExampleService` |
+| `rpc.method` | `Get` |
+| `rpc.grpc.full_method` | `/example.v1.ExampleService/Get` |
+| `span.kind` | `server` / `client` |
+
+Opt-in tags:
+
+- `WithMetadataTags()` — request headers as `connect.metadata.*` tags
+  (propagation headers are excluded by default; add more exclusions with
+  `WithIgnoredMetadata(...)`)
+- `WithRequestTags()` — the request message serialized as JSON in the
+  `connect.request` tag
+
+Note: request messages and headers may contain sensitive or high-cardinality
+data. Prefer enabling these options selectively, or tag specific fields
+yourself via `tracer.SpanFromContext` in your handler.
+
 ## License
 
 This project is licensed under the BSD-3-Clause License - see the [LICENSE](LICENSE) file for details.

--- a/client.go
+++ b/client.go
@@ -1,0 +1,73 @@
+package connect
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+)
+
+var _ connect.Interceptor = (*clientInterceptor)(nil)
+
+type clientInterceptor struct {
+	cfg *config
+}
+
+func (c clientInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		spec := req.Spec()
+		_, im := c.cfg.ignoredMethods[spec.Procedure]
+		_, um := c.cfg.untracedMethods[spec.Procedure]
+		if im || um {
+			return next(ctx, req)
+		}
+		span, ctx := startSpan(
+			ctx,
+			req.Header(),
+			spec.Procedure,
+			c.cfg.spanName,
+			c.cfg.serviceName,
+			false,
+			c.cfg.startSpanOptions(tracer.Measured(),
+				tracer.Tag(ext.SpanKind, ext.SpanKindClient))...,
+		)
+		span.SetTag(tagMethodKind, methodKindUnary)
+		withPeerTags(req.Peer(), span)
+		withMetadataTags(c.cfg, req.Header(), span)
+		withRequestTags(c.cfg, req.Any(), span)
+		// propagate the span context to the server through the request headers
+		_ = tracer.Inject(span.Context(), tracer.HTTPHeadersCarrier(req.Header()))
+		resp, err := next(ctx, req)
+		finishWithError(span, err, c.cfg)
+		return resp, err
+	}
+}
+
+// WrapStreamingClient propagates the active span context to the server through
+// the request headers. Streaming client calls are not traced as spans.
+func (c clientInterceptor) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+	return func(ctx context.Context, spec connect.Spec) connect.StreamingClientConn {
+		conn := next(ctx, spec)
+		if span, ok := tracer.SpanFromContext(ctx); ok {
+			_ = tracer.Inject(span.Context(), tracer.HTTPHeadersCarrier(conn.RequestHeader()))
+		}
+		return conn
+	}
+}
+
+func (c clientInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+	return next
+}
+
+// NewClientInterceptor returns a connect.Interceptor which traces unary client
+// calls and injects the trace context into the request headers so the server
+// can continue the trace.
+func NewClientInterceptor(opts ...Option) connect.Interceptor {
+	cfg := new(config)
+	clientDefaults(cfg)
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	return &clientInterceptor{cfg: cfg}
+}

--- a/connect.go
+++ b/connect.go
@@ -10,6 +10,8 @@ import (
 	"connectrpc.com/connect"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 // cache a constant option: saves one allocation per call
@@ -29,12 +31,16 @@ func (cfg *config) startSpanOptions(opts ...tracer.StartSpanOption) []tracer.Sta
 	return ret
 }
 
+// startSpan starts a span for the given method. When extractParent is true,
+// the parent span context is extracted from the incoming request headers
+// (server side); client spans inherit their parent from ctx instead.
 func startSpan(
 	ctx context.Context,
 	headers http.Header,
 	method string,
 	operation string,
 	serviceFn func() string,
+	extractParent bool,
 	opts ...tracer.StartSpanOption,
 ) (*tracer.Span, context.Context) {
 	// common stuff
@@ -42,6 +48,7 @@ func startSpan(
 		tracer.ServiceName(serviceFn()),
 		tracer.ResourceName(method),
 		tracer.Tag(tagMethodName, method),
+		tracer.Tag(ext.Component, componentName),
 	)
 
 	// gRPC Spec
@@ -52,12 +59,62 @@ func startSpan(
 		tracer.Tag(ext.GRPCFullMethod, method),
 		tracer.Tag(ext.RPCService, methodElements[0]),
 	)
+	if len(methodElements) > 1 {
+		opts = append(opts, tracer.Tag(ext.RPCMethod, methodElements[1]))
+	}
 
 	// http Spec
-	if sctx, err := tracer.Extract(tracer.HTTPHeadersCarrier(headers)); err == nil {
-		opts = append(opts, tracer.ChildOf(sctx)) //nolint:staticcheck // SA1019: tracer.ChildOf is deprecated, but kept for compatibility
+	if extractParent {
+		if sctx, err := tracer.Extract(tracer.HTTPHeadersCarrier(headers)); err == nil {
+			opts = append(opts, tracer.ChildOf(sctx)) //nolint:staticcheck // SA1019: tracer.ChildOf is deprecated, but kept for compatibility
+		}
 	}
 	return tracer.StartSpanFromContext(ctx, operation, opts...)
+}
+
+// withMetadataTags tags the span with the request headers, except for the
+// ones in cfg.ignoredMetadata, when the WithMetadataTags option is enabled.
+func withMetadataTags(cfg *config, headers http.Header, span *tracer.Span) {
+	if !cfg.withMetadataTags {
+		return
+	}
+	for k, v := range headers {
+		k = strings.ToLower(k)
+		if _, ok := cfg.ignoredMetadata[k]; ok {
+			continue
+		}
+		// gRPC binary metadata keys end in "-bin"; skip them for parity with
+		// the dd-trace-go gRPC integration.
+		if strings.HasSuffix(k, "-bin") {
+			continue
+		}
+		span.SetTag(tagMetadataPrefix+k, v)
+	}
+}
+
+// withRequestTags tags the span with the request message serialized as JSON
+// when the WithRequestTags option is enabled.
+func withRequestTags(cfg *config, req any, span *tracer.Span) {
+	if !cfg.withRequestTags {
+		return
+	}
+	if p, ok := req.(proto.Message); ok {
+		if b, err := protojson.Marshal(p); err == nil {
+			span.SetTag(tagRequest, string(b))
+		}
+	}
+}
+
+// withPeerTags tags the span with the RPC protocol (connect, grpc or grpcweb)
+// and the peer address: the client address on server spans, the server host
+// on client spans.
+func withPeerTags(peer connect.Peer, span *tracer.Span) {
+	if peer.Protocol != "" {
+		span.SetTag(tagProtocol, peer.Protocol)
+	}
+	if peer.Addr != "" {
+		span.SetTag(tagPeerAddr, peer.Addr)
+	}
 }
 
 // finishWithError applies finish option and a tag with gRPC status code, disregarding OK, EOF and Canceled errors.
@@ -65,13 +122,15 @@ func finishWithError(span *tracer.Span, err error, cfg *config) {
 	if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) {
 		err = nil
 	}
+	code := codeOK
 	if err != nil {
 		errcode := connect.CodeOf(err)
 		if cfg.nonErrorCodes[errcode] {
 			err = nil
 		}
-		span.SetTag(tagCode, errcode.String())
+		code = errcode.String()
 	}
+	span.SetTag(tagCode, code)
 
 	// only allocate finishOptions if needed, and allocate the exact right size
 	var finishOptions []tracer.FinishOption

--- a/connect_test.go
+++ b/connect_test.go
@@ -69,7 +69,7 @@ func TestStartSpan(t *testing.T) {
 	operation := "test.operation"
 	serviceFn := func() string { return "test-service" }
 
-	span, newCtx := startSpan(ctx, headers, method, operation, serviceFn)
+	span, newCtx := startSpan(ctx, headers, method, operation, serviceFn, true)
 
 	if span == nil {
 		t.Error("expected span to be created")

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	connectrpc.com/connect v1.20.0
 	github.com/DataDog/dd-trace-go/v2 v2.8.2
+	google.golang.org/protobuf v1.36.11
 )
 
 require (
@@ -32,6 +33,7 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
@@ -50,10 +52,12 @@ require (
 	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/puzpuzpuz/xsync/v3 v3.5.1 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.10.0 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.2 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/tinylib/msgp v1.6.3 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
@@ -77,7 +81,6 @@ require (
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260209200024-4cfbd4190f57 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/ini.v1 v1.67.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/interceptor_tags_test.go
+++ b/interceptor_tags_test.go
@@ -1,0 +1,152 @@
+package connect
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/ext"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func TestServerInterceptorSpanTags(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	interceptor := NewServerInterceptor(WithMetadataTags(), WithRequestTags())
+	next := connect.UnaryFunc(func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		return connect.NewResponse(&wrapperspb.StringValue{Value: "world"}), nil
+	})
+
+	req := connect.NewRequest(&wrapperspb.StringValue{Value: "hello"})
+	req.Header().Set("X-Custom-Header", "abc")
+	req.Header().Set("X-Datadog-Trace-Id", "123")
+	req.Header().Set("X-Test-Bin", "binary")
+
+	if _, err := interceptor.WrapUnary(next)(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	spans := mt.FinishedSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	span := spans[0]
+
+	if got := span.Tag(ext.Component); got != "connectrpc.com/connect" {
+		t.Errorf("expected component tag, got %v", got)
+	}
+	if got := span.Tag(ext.RPCSystem); got != "connect" {
+		t.Errorf("expected rpc.system connect, got %v", got)
+	}
+	if got := span.Tag(ext.SpanKind); got != ext.SpanKindServer {
+		t.Errorf("expected span.kind server, got %v", got)
+	}
+	if got := span.Tag(tagCode); got != codeOK {
+		t.Errorf("expected connect.code %q, got %v", codeOK, got)
+	}
+	if got := span.Tag(tagMethodKind); got != methodKindUnary {
+		t.Errorf("expected connect.method.kind unary, got %v", got)
+	}
+	// slice tag values are flattened by the tracer into indexed keys (key.0, key.1, ...)
+	if got := span.Tag(tagMetadataPrefix + "x-custom-header.0"); got != "abc" {
+		t.Errorf("expected connect.metadata.x-custom-header.0 tag to be set, got %v", got)
+	}
+	if got := span.Tag(tagMetadataPrefix + "x-datadog-trace-id.0"); got != nil {
+		t.Errorf("expected x-datadog-trace-id to be ignored, got %v", got)
+	}
+	if got := span.Tag(tagMetadataPrefix + "x-test-bin.0"); got != nil {
+		t.Errorf("expected -bin metadata to be skipped, got %v", got)
+	}
+	reqTag, _ := span.Tag(tagRequest).(string)
+	if !strings.Contains(reqTag, "hello") {
+		t.Errorf("expected connect.request tag to contain the message, got %q", reqTag)
+	}
+}
+
+func TestServerInterceptorSpanTagsDisabledByDefault(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	interceptor := NewServerInterceptor()
+	next := connect.UnaryFunc(func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		return connect.NewResponse(&wrapperspb.StringValue{}), nil
+	})
+
+	req := connect.NewRequest(&wrapperspb.StringValue{Value: "hello"})
+	req.Header().Set("X-Custom-Header", "abc")
+
+	if _, err := interceptor.WrapUnary(next)(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	span := mt.FinishedSpans()[0]
+	if got := span.Tag(tagMetadataPrefix + "x-custom-header"); got != nil {
+		t.Errorf("expected no metadata tags by default, got %v", got)
+	}
+	if got := span.Tag(tagRequest); got != nil {
+		t.Errorf("expected no request tag by default, got %v", got)
+	}
+}
+
+func TestServerInterceptorErrorCode(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	interceptor := NewServerInterceptor()
+	next := connect.UnaryFunc(func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		return nil, connect.NewError(connect.CodeInternal, errors.New("boom"))
+	})
+
+	req := connect.NewRequest(&wrapperspb.StringValue{})
+	if _, err := interceptor.WrapUnary(next)(context.Background(), req); err == nil {
+		t.Fatal("expected error")
+	}
+
+	span := mt.FinishedSpans()[0]
+	if got := span.Tag(tagCode); got != connect.CodeInternal.String() {
+		t.Errorf("expected connect.code internal, got %v", got)
+	}
+}
+
+func TestClientInterceptorSpanTagsAndPropagation(t *testing.T) {
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	interceptor := NewClientInterceptor(WithRequestTags())
+	var propagated bool
+	next := connect.UnaryFunc(func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		propagated = req.Header().Get("X-Datadog-Trace-Id") != ""
+		return connect.NewResponse(&wrapperspb.StringValue{}), nil
+	})
+
+	req := connect.NewRequest(&wrapperspb.StringValue{Value: "hello"})
+	if _, err := interceptor.WrapUnary(next)(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !propagated {
+		t.Error("expected trace context to be injected into request headers")
+	}
+
+	span := mt.FinishedSpans()[0]
+	if got := span.OperationName(); got != "connect.client.request" {
+		t.Errorf("expected operation name connect.client.request, got %v", got)
+	}
+	if got := span.Tag(ext.SpanKind); got != ext.SpanKindClient {
+		t.Errorf("expected span.kind client, got %v", got)
+	}
+	if got := span.Tag(ext.ServiceName); got != defaultClientServiceName {
+		t.Errorf("expected service %q, got %v", defaultClientServiceName, got)
+	}
+	if got := span.Tag(tagCode); got != codeOK {
+		t.Errorf("expected connect.code ok, got %v", got)
+	}
+	reqTag, _ := span.Tag(tagRequest).(string)
+	if !strings.Contains(reqTag, "hello") {
+		t.Errorf("expected connect.request tag to contain the message, got %q", reqTag)
+	}
+}

--- a/option.go
+++ b/option.go
@@ -7,6 +7,7 @@ import (
 
 const (
 	defaultServerServiceName = "connect.server"
+	defaultClientServiceName = "connect.client"
 )
 
 // Option specifies a configuration option for the grpc package. Not all options apply
@@ -46,6 +47,9 @@ func defaults(cfg *config) {
 		"x-datadog-trace-id":          {},
 		"x-datadog-parent-id":         {},
 		"x-datadog-sampling-priority": {},
+		"x-datadog-tags":              {},
+		"traceparent":                 {},
+		"tracestate":                  {},
 	}
 }
 
@@ -54,6 +58,12 @@ func serverDefaults(cfg *config) {
 	// before the call `tracer.Start()`
 	cfg.serviceName = func() string { return defaultServerServiceName }
 	cfg.spanName = "connect.server.request"
+	defaults(cfg)
+}
+
+func clientDefaults(cfg *config) {
+	cfg.serviceName = func() string { return defaultClientServiceName }
+	cfg.spanName = "connect.client.request"
 	defaults(cfg)
 }
 
@@ -145,7 +155,8 @@ func WithUntracedMethods(ms ...string) Option {
 	}
 }
 
-// WithMetadataTags specifies whether gRPC metadata should be added to spans as tags.
+// WithMetadataTags specifies whether request headers (metadata) should be added
+// to spans as connect.metadata.* tags.
 func WithMetadataTags() Option {
 	return func(cfg *config) {
 		cfg.withMetadataTags = true
@@ -162,7 +173,8 @@ func WithIgnoredMetadata(ms ...string) Option {
 	}
 }
 
-// WithRequestTags specifies whether gRPC requests should be added to spans as tags.
+// WithRequestTags specifies whether request messages should be added to spans
+// as the connect.request tag, serialized as JSON.
 func WithRequestTags() Option {
 	return func(cfg *config) {
 		cfg.withRequestTags = true

--- a/server.go
+++ b/server.go
@@ -27,9 +27,12 @@ func (c *wrappedStreamingHandlerConn) Receive(m any) (err error) {
 			methodName,
 			"connect.message",
 			c.cfg.serviceName,
+			true,
 			c.cfg.startSpanOptions(tracer.Measured())...,
 		)
 		defer func() {
+			withMetadataTags(c.cfg, c.RequestHeader(), span)
+			withRequestTags(c.cfg, m, span)
 			finishWithError(span, err, c.cfg)
 		}()
 	}
@@ -46,8 +49,9 @@ func (c *wrappedStreamingHandlerConn) Send(m any) (err error) {
 			c.ctx,
 			c.RequestHeader(),
 			methodName,
-			"grpc.message",
+			"connect.message",
 			c.cfg.serviceName,
+			true,
 			c.cfg.startSpanOptions(tracer.Measured())...,
 		)
 		defer func() { finishWithError(span, err, c.cfg) }()
@@ -76,10 +80,14 @@ func (s serverInterceptor) WrapUnary(unaryFunc connect.UnaryFunc) connect.UnaryF
 			spec.Procedure,
 			s.cfg.spanName,
 			s.cfg.serviceName,
+			true,
 			s.cfg.startSpanOptions(tracer.Measured(),
 				tracer.Tag(ext.SpanKind, ext.SpanKindServer))...,
 		)
 		span.SetTag(tagMethodKind, methodKindUnary)
+		withPeerTags(req.Peer(), span)
+		withMetadataTags(s.cfg, req.Header(), span)
+		withRequestTags(s.cfg, req.Any(), span)
 		resp, err := unaryFunc(ctx, req)
 		finishWithError(span, err, s.cfg)
 		return resp, err
@@ -103,9 +111,12 @@ func (s serverInterceptor) WrapStreamingHandler(handlerFunc connect.StreamingHan
 				spec.Procedure,
 				s.cfg.spanName,
 				s.cfg.serviceName,
+				true,
 				s.cfg.startSpanOptions(tracer.Measured(),
 					tracer.Tag(ext.SpanKind, ext.SpanKindServer))...,
 			)
+			withPeerTags(conn.Peer(), span)
+			withMetadataTags(s.cfg, conn.RequestHeader(), span)
 			switch conn.Spec().StreamType {
 			case connect.StreamTypeBidi:
 				span.SetTag(tagMethodKind, methodKindBidiStream)

--- a/tags.go
+++ b/tags.go
@@ -1,9 +1,13 @@
 package connect
 
 const (
-	tagMethodName = "connect.method.name"
-	tagMethodKind = "connect.method.kind"
-	tagCode       = "connect.code"
+	tagMethodName     = "connect.method.name"
+	tagMethodKind     = "connect.method.kind"
+	tagCode           = "connect.code"
+	tagMetadataPrefix = "connect.metadata."
+	tagRequest        = "connect.request"
+	tagProtocol       = "connect.protocol"
+	tagPeerAddr       = "connect.peer.addr"
 )
 
 const (
@@ -15,4 +19,12 @@ const (
 
 const (
 	extRPCSystemConnect = "connect"
+
+	// componentName identifies this integration in the ext.Component tag.
+	componentName = "connectrpc.com/connect"
+
+	// codeOK is the connect.code tag value for successful calls. connect-go
+	// has no explicit OK code, so this mirrors gRPC's codes.OK in connect's
+	// lowercase code style.
+	codeOK = "ok"
 )


### PR DESCRIPTION
## 概要

`connect.server.request` スパンに付く情報が最小限だったため、公式の dd-trace-go gRPC integration ([contrib/google.golang.org/grpc](https://github.com/DataDog/dd-trace-go/tree/main/contrib/google.golang.org/grpc)) に倣ってタグを拡充します。

## 変更内容

### デッドコードだったオプションの実装

`WithMetadataTags()` / `WithRequestTags()` / `WithIgnoredMetadata()` はオプションとして存在していましたが、config フィールドがどこからも参照されておらず機能していませんでした。公式 gRPC contrib と同じ挙動で実装しています。

- `WithMetadataTags()`: リクエストヘッダーを `connect.metadata.*` タグとして付与(`-bin` キーはスキップ)。デフォルト除外リストに `x-datadog-tags` / `traceparent` / `tracestate` を追加
- `WithRequestTags()`: リクエストメッセージを protojson でシリアライズし `connect.request` タグとして付与

### 無条件で付与するタグの追加

- `connect.code`: 成功時も `ok` を付与(従来はエラー時のみ。公式の `grpc.code: OK` 相当)
- `component: connectrpc.com/connect`
- `rpc.method`: メソッド短縮名(例: `Show`)
- `connect.protocol`: `connect` / `grpc` / `grpcweb`
- `connect.peer.addr`: サーバースパンではクライアントアドレス、クライアントスパンでは接続先ホスト

### NewClientInterceptor の新設

unary クライアント呼び出しを `connect.client.request` スパン(`span.kind: client`)としてトレースし、トレースコンテキストをリクエストヘッダーに注入します。ストリーミングクライアントはコンテキスト伝播のみ。手動でのスパン作成 + 独自の inject インターセプタが不要になります。

### バグ修正

- ストリーミングの `Send` メッセージスパンの operation 名が `grpc.message` になっていた移植ミスを `connect.message` に修正

## テスト

- mocktracer ベースのテストを追加 (`interceptor_tags_test.go`): 新タグの付与、オプトインタグがデフォルト無効であること、エラー時の `connect.code`、クライアント側のヘッダー伝播を検証
- `go test ./...` / `go vet` / `gofmt` パス確認済み

## 互換性

- `startSpan` のシグネチャ変更は非公開関数のため影響なし
- 既存スパンへの追加タグのみで、既存のタグ・スパン名は変更なし(`Send` の operation 名修正を除く)
- `google.golang.org/protobuf` が direct dependency になります(connect-go 経由で既に間接依存)

🤖 Generated with [Claude Code](https://claude.com/claude-code)